### PR TITLE
use subprocess.Popen(..) for pdftk/stapler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+springer_download.log


### PR DESCRIPTION
use subprocess.Popen(..) in pdftk/stapler calls to avoid shell escaping for ' in filenames inherited from booktitle
