### PR TITLE
Bug-Fix for calling with no-merge option

### DIFF
--- a/springer_download.py
+++ b/springer_download.py
@@ -34,6 +34,10 @@ def main(argv):
     if not findInPath("iconv"):
         error("You have to install iconv.")
 
+    #Test if convert is installed
+    if os.system("convert --version > /dev/null 2>&1")!=0:
+        error("You have to install the packet ImageMagick in order to use convert")
+
     try:
         opts, args = getopt.getopt(argv, "hl:c:n", ["help", "link=", "content=", "no-merge"])
     except getopt.GetoptError:

--- a/springer_download.py
+++ b/springer_download.py
@@ -208,10 +208,11 @@ def main(argv):
         shutil.rmtree(tempDir)
 
         print "book %s was successfully downloaded, it was saved to %s" % (bookTitle, bookTitlePath)
-    else:
+        log("downloaded %s chapters (%.2fMiB) of %s\n" % (len(chapters),  os.path.getsize(bookTitlePath)/2.0**20, bookTitle))
+    else: #HL: if merge=False
         print "book %s was successfully downloaded, unmerged chapters can be found in %s" % (bookTitle, tempDir)
+        log("downloaded %s chapters of %s\n" % (len(chapters), bookTitle))
 
-    log("downloaded %s chapters (%.2fMiB) of %s\n" % (len(chapters),  os.path.getsize(bookTitlePath)/2.0**20, bookTitle))
     sys.exit()
 
 # give a usage message


### PR DESCRIPTION
By calling springer_download.py with the option no-merge you do not get the size of the merge PDF, because there is no merged PDF. So the script has to fail by logging the size.
After the bug-fix the size is only logged if there is a merged PDF.

Best Regards Hanno

Log:
book The holy bible was successfully downloaded, unmerged chapters can be found in /tmp/tmpgk_dKS
Traceback (most recent call last):
  File "./springer_download.py", line 309, in <module>
    main(sys.argv[1:])
  File "./springer_download.py", line 229, in main
    log("downloaded %s chapters (%.2fMiB) of %s\n" % (len(chapters),  os.path.getsize(bookTitlePath)/2.0**20, bookTitle))
  File "/usr/lib/python2.6/genericpath.py", line 49, in getsize
    return os.stat(filename).st_size
OSError: [Errno 2] No such file or directory: '/tmp/Bible.pdf'
